### PR TITLE
Corrected Info.plist for macOS builds

### DIFF
--- a/platform/Apple/bundles/EDuke32.app/Contents/Info.plist
+++ b/platform/Apple/bundles/EDuke32.app/Contents/Info.plist
@@ -7,13 +7,13 @@
 	<key>CFBundleDisplayName</key>
 	<string>EDuke32</string>
 	<key>CFBundleExecutable</key>
-	<string>eduke32</string>
+	<string>amcsquad</string>
 	<key>CFBundleGetInfoString</key>
 	<string>2.0, Copyright EDuke32 Team</string>
 	<key>CFBundleIconFile</key>
 	<string>eduke32.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>com.eduke32.eduke32</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
There are a couple issues with the Info.plist file that prevented EDuke32.app from executing. The corrected Info.plist references the "amcsquad" executable and adds an identifier string.

Note that AMC Squad itself still runs extremely poorly with Polymost and OpenGL on macOS but at least you can run it now :) 